### PR TITLE
Fixing nil pointer panic

### DIFF
--- a/pkg/service/output/prometheus.go
+++ b/pkg/service/output/prometheus.go
@@ -140,7 +140,9 @@ func (p *prometheusOutput) Collect(ch chan<- prometheus.Metric) {
 
 		// If metric has expired then remove from the map.
 		if time.Now().After(metric.expire) {
-			p.logger.With("slo", metric.slo.Name).With("service-level", metric.serviceLevel.Name).Infof("metric expired, removing")
+			if metric.slo != nil && metric.serviceLevel != nil {
+				p.logger.With("slo", metric.slo.Name).With("service-level", metric.serviceLevel.Name).Infof("metric expired, removing")
+			}
 			delete(p.metricValues, id)
 			continue
 		}


### PR DESCRIPTION
Attempt to fix:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x106b4b5]

goroutine 2027 [running]:
github.com/Medium/service-level-operator/pkg/service/output.(*prometheusOutput).Collect(0xc00054e5c0, 0xc0008952c0)
	/src/pkg/service/output/prometheus.go:143 +0x415
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/go/pkg/mod/github.com/prometheus/client_golang@v1.2.1/prometheus/registry.go:445 +0x164
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/go/pkg/mod/github.com/prometheus/client_golang@v1.2.1/prometheus/registry.go:535 +0xe12
```